### PR TITLE
Fix: Figshare API lists and downloads only 10 files if page size is not specified

### DIFF
--- a/figshare/figshare.py
+++ b/figshare/figshare.py
@@ -109,6 +109,7 @@ class Figshare:
 
         self.token = token
         self.private = private
+        self.page_size = 1000
 
     def endpoint(self, link):
         """Concatenate the endpoint to the baseurl"""
@@ -275,7 +276,8 @@ class Figshare:
             else:
                 url = self.endpoint('/articles/{}/files'.format(article_id))
             headers = self.get_headers(self.token)
-            response = issue_request('GET', url, headers=headers)
+            params = {'page_size': self.page_size}
+            response = issue_request('GET', url, headers=headers, params=params)
             return response
         else:
             request = self.get_article_details(article_id, version)


### PR DESCRIPTION
**Description**

This PR includes the page size parameter in the private article file API call. The parameter will modify the default value of 10 which makes the API return on only 10 files if an article contains more than 10 files.

It uses #10 for `feature/issue_request_params` (PR #1) to include the `page_size` parameter in the API call.

